### PR TITLE
Create auction frontend and unified styling

### DIFF
--- a/AutoAuction_H2/App.axaml
+++ b/AutoAuction_H2/App.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:AutoAuction_H2"
              xmlns:converters="clr-namespace:AutoAuction_H2.Converters"
-			 xmlns:fluent="clr-namespace:Avalonia.Themes.Fluent;assembly=Avalonia.Themes.Fluent"
+             xmlns:fluent="clr-namespace:Avalonia.Themes.Fluent;assembly=Avalonia.Themes.Fluent"
              x:Class="AutoAuction_H2.App"
              RequestedThemeVariant="Dark">
 
@@ -10,12 +10,55 @@
         <local:ViewLocator/>
     </Application.DataTemplates>
 
-	<Application.Resources>
-		<converters:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
-	</Application.Resources>
+    <Application.Resources>
+        <converters:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
+
+        <!-- Shared brushes for app styling -->
+        <SolidColorBrush x:Key="PanelBackgroundBrush" Color="#202020C0"/>
+        <SolidColorBrush x:Key="CardBackgroundBrush" Color="#2B2B2BE6"/>
+        <SolidColorBrush x:Key="ContrastBorderBrush" Color="Snow"/>
+        <SolidColorBrush x:Key="AccentBrush" Color="#00CFE6"/>
+    </Application.Resources>
 
     <Application.Styles>
         <!-- Load Fluent Theme -->
         <fluent:FluentTheme />
+
+        <!-- Global styles to align controls with windows look -->
+        <Style Selector="Button.accent">
+            <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Height" Value="36"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+        </Style>
+        <Style Selector="Button.secondary">
+            <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="#3A3A3A"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Height" Value="36"/>
+        </Style>
+        <Style Selector="TextBox.search">
+            <Setter Property="Height" Value="36"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
+            <Setter Property="Foreground" Value="Black"/>
+            <!-- Use numeric entity for ø to avoid encoding issues -->
+            <Setter Property="Watermark" Value="S&#248;g auktioner..."/>
+            <Setter Property="Padding" Value="10,6"/>
+        </Style>
+        <Style Selector="TextBlock.bid">
+            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+        </Style>
+        <Style Selector="DataGrid">
+            <Setter Property="BorderBrush" Value="#3A3A3A"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Background" Value="#1E1E1E"/>
+            <Setter Property="RowBackground" Value="#242424"/>
+            <Setter Property="HorizontalGridLinesBrush" Value="#333"/>
+            <Setter Property="VerticalGridLinesBrush" Value="#333"/>
+        </Style>
     </Application.Styles>
 </Application>

--- a/AutoAuction_H2/AutoAuction_H2.csproj
+++ b/AutoAuction_H2/AutoAuction_H2.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
   
   <ItemGroup>
@@ -15,6 +15,7 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Include="Avalonia.Diagnostics">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/AutoAuction_H2/Models/AuctionItem.cs
+++ b/AutoAuction_H2/Models/AuctionItem.cs
@@ -1,0 +1,9 @@
+namespace AutoAuction_H2.Models;
+
+public class AuctionItem
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Year { get; set; }
+    public decimal CurrentBid { get; set; }
+}

--- a/AutoAuction_H2/Models/User.cs
+++ b/AutoAuction_H2/Models/User.cs
@@ -26,20 +26,17 @@ public abstract class User : IUser
         ZipCode = zipCode;
     }
 
-    // Hash password with SHA256
     public static string HashPassword(string password)
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(password));
         return Convert.ToBase64String(bytes);
     }
 
-    // Validate username (min length and not empty)
     public static bool ValidateUserName(string userName)
     {
         return !string.IsNullOrWhiteSpace(userName) && userName.Length >= 3;
     }
 
-    // Override ToString for better display
     public override string ToString()
     {
         return $"User: ID={ID}, UserName={UserName}, Saldo={Saldo}, ZipCode={ZipCode}";

--- a/AutoAuction_H2/ViewLocator.cs
+++ b/AutoAuction_H2/ViewLocator.cs
@@ -12,8 +12,20 @@ public class ViewLocator : IDataTemplate
         if (param is null)
             return null;
 
-        var name = param.GetType().FullName!.Replace("ViewModel", "View", StringComparison.Ordinal);
+        var vmType = param.GetType();
+        var name = vmType.FullName!
+            .Replace(".ViewModels.", ".Views.", StringComparison.Ordinal)
+            .Replace("ViewModel", "View", StringComparison.Ordinal);
+
+        // Try resolve directly
         var type = Type.GetType(name);
+
+        // Also try the ContentPanels namespace if the first attempt fails
+        if (type is null)
+        {
+            var contentPanelsName = name.Replace(".Views.", ".Views.ContentPanels.", StringComparison.Ordinal);
+            type = Type.GetType(contentPanelsName);
+        }
 
         if (type != null)
         {

--- a/AutoAuction_H2/ViewModels/AuctionOverviewViewModel.cs
+++ b/AutoAuction_H2/ViewModels/AuctionOverviewViewModel.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoAuction_H2.ViewModels;
+using System.Collections.ObjectModel;
+using AutoAuction_H2.Models;
+
+namespace AutoAuction_H2.ViewModels
+{
+    public partial class AuctionOverviewViewModel : ViewModelBase
+    {
+        public ObservableCollection<AuctionItem> CurrentAuctions { get; } = new()
+        {
+            new AuctionItem { Id = 1, Name = "Mercedes C-klasse", Year = 2018, CurrentBid = 250000 },
+            new AuctionItem { Id = 2, Name = "BMW X5", Year = 2020, CurrentBid = 400000 },
+            new AuctionItem { Id = 3, Name = "Porsche 911", Year = 2015, CurrentBid = 900000 },
+            new AuctionItem { Id = 4, Name = "Ford Mustang", Year = 2022, CurrentBid = 550000 },
+            new AuctionItem { Id = 5, Name = "Skoda Octavia", Year = 2019, CurrentBid = 180000 },
+            new AuctionItem { Id = 6, Name = "Tesla Model 3", Year = 2021, CurrentBid = 380000 },
+        };
+
+        public ObservableCollection<AuctionItem> YourAuctions { get; } = new()
+        {
+            new AuctionItem { Id = 10, Name = "Volvo V70", Year = 1998, CurrentBid = 15000 },
+            new AuctionItem { Id = 11, Name = "Audi A4", Year = 2010, CurrentBid = 45000 },
+            new AuctionItem { Id = 12, Name = "Volkswagen Golf", Year = 2005, CurrentBid = 22000 },
+            new AuctionItem { Id = 13, Name = "Ford Focus", Year = 2012, CurrentBid = 30000 },
+            new AuctionItem { Id = 14, Name = "Toyota Corolla", Year = 2008, CurrentBid = 28000 },
+        };
+    }
+}

--- a/AutoAuction_H2/ViewModels/ChangePasswordViewModel.cs
+++ b/AutoAuction_H2/ViewModels/ChangePasswordViewModel.cs
@@ -1,0 +1,81 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoAuction_H2.ViewModels;
+
+public partial class ChangePasswordViewModel : ObservableObject
+{
+    [ObservableProperty] private string currentPassword = string.Empty;
+    [ObservableProperty] private string newPassword = string.Empty;
+    [ObservableProperty] private string confirmPassword = string.Empty;
+    [ObservableProperty] private string? errorMessage;
+
+    public IAsyncRelayCommand SaveCommand { get; }
+
+    public ChangePasswordViewModel()
+    {
+        SaveCommand = new AsyncRelayCommand(SaveAsync);
+    }
+
+    private async Task SaveAsync()
+    {
+        ErrorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(CurrentPassword) || string.IsNullOrWhiteSpace(NewPassword) || string.IsNullOrWhiteSpace(ConfirmPassword))
+        {
+            ErrorMessage = "Udfyld venligst alle felter.";
+            return;
+        }
+        if (NewPassword != ConfirmPassword)
+        {
+            ErrorMessage = "Den nye adgangskode og bekræftelsen er ikke ens.";
+            return;
+        }
+        if (NewPassword.Length < 6)
+        {
+            ErrorMessage = "Adgangskoden skal mindst være 6 tegn.";
+            return;
+        }
+
+        try
+        {
+            // Hash passwords (SHA256)
+            static string Hash(string s)
+            {
+                var bytes = Encoding.UTF8.GetBytes(s);
+                return Convert.ToBase64String(SHA256.HashData(bytes));
+            }
+
+            var request = new
+            {
+                Username = LoginViewModel.CurrentUsername,
+                CurrentPasswordHash = Hash(CurrentPassword),
+                NewPasswordHash = Hash(NewPassword)
+            };
+
+            using var client = new HttpClient { BaseAddress = new Uri("https://localhost:44372/") };
+            var response = await client.PostAsJsonAsync("api/auth/change-password", request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                ErrorMessage = "Kunne ikke ændre adgangskode. Tjek nuværende adgangskode og prøv igen.";
+                return;
+            }
+
+            // Success: try close window via WeakReferenceMessenger or event
+            PasswordChanged?.Invoke(this, EventArgs.Empty);
+        }
+        catch
+        {
+            ErrorMessage = "Der opstod en fejl. Prøv igen senere.";
+        }
+    }
+
+    public event EventHandler? PasswordChanged;
+}

--- a/AutoAuction_H2/ViewModels/CreateAuctionViewModel.cs
+++ b/AutoAuction_H2/ViewModels/CreateAuctionViewModel.cs
@@ -1,0 +1,54 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AutoAuction_H2.ViewModels;
+
+public partial class CreateAuctionViewModel : ObservableObject
+{
+    [ObservableProperty] private string name = string.Empty;
+    [ObservableProperty] private int? mileage;
+    [ObservableProperty] private string regNumber = string.Empty;
+    [ObservableProperty] private int? year;
+
+    public IReadOnlyList<int> Years { get; } = Enumerable.Range(1990, DateTime.Now.Year - 1990 + 1).Reverse().ToList();
+
+    public IReadOnlyList<string> VehicleTypes { get; } = new[] { "Bil", "Truck", "Bus", "Varevogn" };
+    [ObservableProperty] private string? selectedVehicleType = "Bil";
+
+    [ObservableProperty] private decimal? height;
+    [ObservableProperty] private decimal? length;
+    [ObservableProperty] private decimal? weight;
+    [ObservableProperty] private decimal? engineSize;
+    [ObservableProperty] private bool towBar;
+
+    [ObservableProperty] private decimal? startingBid;
+    [ObservableProperty] private DateTimeOffset? closeDate = DateTimeOffset.Now.Date.AddDays(7);
+
+    [ObservableProperty] private string? errorMessage;
+
+    public IAsyncRelayCommand CreateCommand { get; }
+
+    public CreateAuctionViewModel()
+    {
+        CreateCommand = new AsyncRelayCommand(CreateAsync);
+    }
+
+    private async Task CreateAsync()
+    {
+        ErrorMessage = null;
+        if (string.IsNullOrWhiteSpace(Name)) { ErrorMessage = "Udfyld navn."; return; }
+        if (Year is null) { ErrorMessage = "Vælg årgang."; return; }
+        if (StartingBid is null || StartingBid <= 0) { ErrorMessage = "Angiv startbud."; return; }
+        if (CloseDate is null || CloseDate <= DateTimeOffset.Now.Date) { ErrorMessage = "Vælg slutdato frem i tiden."; return; }
+
+        // TODO: Kald API for at oprette auktion
+        await Task.Delay(100); // placeholder
+        AuctionCreated?.Invoke(this, EventArgs.Empty);
+    }
+
+    public event EventHandler? AuctionCreated;
+}

--- a/AutoAuction_H2/ViewModels/MainViewModel.cs
+++ b/AutoAuction_H2/ViewModels/MainViewModel.cs
@@ -3,10 +3,29 @@ using Avalonia.Controls.Primitives;
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace AutoAuction_H2.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
     public ObservableCollection<Vehicle> Vehicles { get; } = new ObservableCollection<Vehicle>();
+
+    [ObservableProperty]
+    private ViewModelBase? currentContent;
+
+    public IRelayCommand ShowAuctionOverviewCommand { get; }
+
+    public MainViewModel()
+    {
+        ShowAuctionOverviewCommand = new RelayCommand(ShowAuctionOverview);
+        // Optionally set a default viewmodel
+        // CurrentContent = new SomeDefaultViewModel();
+    }
+
+    private void ShowAuctionOverview()
+    {
+        CurrentContent = new AuctionOverviewViewModel();
+    }
 }

--- a/AutoAuction_H2/ViewModels/UserProfileViewModel.cs
+++ b/AutoAuction_H2/ViewModels/UserProfileViewModel.cs
@@ -1,0 +1,11 @@
+using AutoAuction_H2.ViewModels;
+
+namespace AutoAuction_H2.ViewModels;
+
+public class UserProfileViewModel : ViewModelBase
+{
+    public string Username { get; set; } = "";
+    public decimal Balance { get; set; }
+    public int YourAuctionsCount { get; set; }
+    public int AuctionsWonCount { get; set; }
+}

--- a/AutoAuction_H2/Views/Auction/Controls/AuctionSidebar.axaml
+++ b/AutoAuction_H2/Views/Auction/Controls/AuctionSidebar.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AutoAuction_H2.Views.Auction.Controls.AuctionSidebar"
+             Width="200">
+  <Border CornerRadius="10" Padding="12" Background="{StaticResource CardBackgroundBrush}">
+    <StackPanel Spacing="10">
+      <TextBlock Text="Auktioner" FontWeight="SemiBold"/>
+      <TextBox Classes="search" Watermark="S&#248;g auktioner..."/>
+      <Button Classes="accent" Content="+ Sæt til salg" Click="Create_Click"/>
+      <Button Classes="secondary" Content="Budhistorik"/>
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/AutoAuction_H2/Views/Auction/Controls/AuctionSidebar.axaml.cs
+++ b/AutoAuction_H2/Views/Auction/Controls/AuctionSidebar.axaml.cs
@@ -1,0 +1,28 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using AutoAuction_H2.Views.Windows;
+using Avalonia.Markup.Xaml;
+
+namespace AutoAuction_H2.Views.Auction.Controls;
+
+public partial class AuctionSidebar : UserControl
+{
+    public AuctionSidebar()
+    {
+        InitializeComponent();
+    }
+
+    private async void Create_Click(object? sender, RoutedEventArgs e)
+    {
+        var win = new CreateAuctionWindow();
+        if (VisualRoot is Window owner)
+            await win.ShowDialog(owner);
+        else
+            win.Show();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/AutoAuction_H2/Views/Auction/Controls/AuctionTable.axaml
+++ b/AutoAuction_H2/Views/Auction/Controls/AuctionTable.axaml
@@ -1,0 +1,26 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AutoAuction_H2.Views.Auction.Controls.AuctionTable">
+  <Border CornerRadius="10" Padding="12" Background="{StaticResource CardBackgroundBrush}">
+    <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" HeadersVisibility="All" CanUserReorderColumns="False" CanUserSortColumns="False">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Navn" Binding="{Binding Name}"/>
+        <DataGridTextColumn Header="Årgang" Binding="{Binding Year}"/>
+        <DataGridTemplateColumn Header="Bud">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate>
+              <TextBlock Classes="bid" Text="{Binding CurrentBid, StringFormat='{}{0:N0} kr.'}"/>
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+        <DataGridTemplateColumn Header="Handling">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate>
+              <Button Classes="accent" Content="Byd"/>
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+      </DataGrid.Columns>
+    </DataGrid>
+  </Border>
+</UserControl>

--- a/AutoAuction_H2/Views/Auction/Controls/AuctionTable.axaml.cs
+++ b/AutoAuction_H2/Views/Auction/Controls/AuctionTable.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using System.Collections;
+
+namespace AutoAuction_H2.Views.Auction.Controls;
+
+public partial class AuctionTable : UserControl
+{
+    public static readonly StyledProperty<IEnumerable?> ItemsProperty =
+        AvaloniaProperty.Register<AuctionTable, IEnumerable?>(nameof(Items));
+
+    public IEnumerable? Items
+    {
+        get => GetValue(ItemsProperty);
+        set => SetValue(ItemsProperty, value);
+    }
+
+    public AuctionTable()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/AutoAuction_H2/Views/Auction/Controls/CreateAuctionBasicInfoCard.axaml
+++ b/AutoAuction_H2/Views/Auction/Controls/CreateAuctionBasicInfoCard.axaml
@@ -1,0 +1,22 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AutoAuction_H2.Views.Auction.Controls.CreateAuctionBasicInfoCard">
+  <Border Background="{StaticResource CardBackgroundBrush}" CornerRadius="12" Padding="20">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="160,*" RowSpacing="14" ColumnSpacing="16">
+      <!-- Header -->
+      <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Spacing="6">
+        <TextBlock Text="Auktions Detaljer" FontWeight="SemiBold" FontSize="18"/>
+        <Rectangle Height="1" Fill="#3A3A3A"/>
+      </StackPanel>
+
+      <TextBlock Text="Navn" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Name}"/>
+
+      <TextBlock Text="Startbud" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding StartingBid}"/>
+
+      <TextBlock Text="Slutdato" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
+      <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding CloseDate}"/>
+    </Grid>
+  </Border>
+</UserControl>

--- a/AutoAuction_H2/Views/Auction/Controls/CreateAuctionBasicInfoCard.axaml.cs
+++ b/AutoAuction_H2/Views/Auction/Controls/CreateAuctionBasicInfoCard.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AutoAuction_H2.Views.Auction.Controls;
+
+public partial class CreateAuctionBasicInfoCard : UserControl
+{
+    public CreateAuctionBasicInfoCard()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/AutoAuction_H2/Views/Auction/Controls/CreateAuctionVehicleDetailsCard.axaml
+++ b/AutoAuction_H2/Views/Auction/Controls/CreateAuctionVehicleDetailsCard.axaml
@@ -1,0 +1,43 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AutoAuction_H2.Views.Auction.Controls.CreateAuctionVehicleDetailsCard">
+  <Border Background="{StaticResource CardBackgroundBrush}" CornerRadius="12" Padding="20">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="160,*" RowSpacing="14" ColumnSpacing="16">
+      <!-- Header -->
+      <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Spacing="6">
+        <TextBlock Text="K&#248;ret&#248;js Detaljer" FontWeight="SemiBold" FontSize="18"/>
+        <Rectangle Height="1" Fill="#3A3A3A"/>
+      </StackPanel>
+
+      <TextBlock Text="Kilometer" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Mileage}"/>
+
+      <TextBlock Text="Reg.nr." Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RegNumber}"/>
+
+      <TextBlock Text="Årgang" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
+      <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding Years}" SelectedItem="{Binding Year}"/>
+
+      <TextBlock Text="K&#248;ret&#248;jstype" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
+      <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding VehicleTypes}" SelectedItem="{Binding SelectedVehicleType}"/>
+
+      <TextBlock Text="H&#248;jde" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Height}"/>
+
+      <TextBlock Text="L&#230;ngde" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding Length}"/>
+
+      <TextBlock Text="V&#230;gt" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding Weight}"/>
+
+      <TextBlock Text="Motorst&#248;rrelse" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
+      <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding EngineSize}"/>
+
+      <TextBlock Text="Tr&#230;k" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
+      <StackPanel Grid.Row="9" Grid.Column="1" Orientation="Horizontal" Spacing="12">
+        <RadioButton Content="Ja" IsChecked="{Binding TowBar}"/>
+        <RadioButton Content="Nej" IsChecked="{Binding TowBar, Converter={StaticResource InverseBooleanConverter}}"/>
+      </StackPanel>
+    </Grid>
+  </Border>
+</UserControl>

--- a/AutoAuction_H2/Views/Auction/Controls/CreateAuctionVehicleDetailsCard.axaml.cs
+++ b/AutoAuction_H2/Views/Auction/Controls/CreateAuctionVehicleDetailsCard.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AutoAuction_H2.Views.Auction.Controls;
+
+public partial class CreateAuctionVehicleDetailsCard : UserControl
+{
+    public CreateAuctionVehicleDetailsCard()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/AutoAuction_H2/Views/ContentPanels/AuctionOverviewView.axaml
+++ b/AutoAuction_H2/Views/ContentPanels/AuctionOverviewView.axaml
@@ -1,0 +1,30 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ac="clr-namespace:AutoAuction_H2.Views.Auction.Controls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="AutoAuction_H2.Views.ContentPanels.AuctionOverviewView">
+  <Border CornerRadius="12" Background="{StaticResource PanelBackgroundBrush}" Padding="12">
+    <Grid ColumnDefinitions="210,*" ColumnSpacing="16">
+      <!-- Background image to match window styling -->
+      <Image Source="avares://AutoAuction_H2/Assets/BackgroundImage.png"
+             Stretch="UniformToFill"
+             Opacity="0.25"
+             IsHitTestVisible="False"
+             Grid.ColumnSpan="2"/>
+
+      <!-- Left sidebar -->
+      <ac:AuctionSidebar Grid.Column="0"/>
+
+      <!-- Right side content -->
+      <StackPanel Grid.Column="1" Spacing="12">
+        <TextBlock Text="Aktuelle auktioner" FontSize="18" FontWeight="SemiBold"/>
+        <ac:AuctionTable/>
+
+        <TextBlock Text="Dine auktioner" FontSize="18" FontWeight="SemiBold" Margin="0,8,0,0"/>
+        <ac:AuctionTable/>
+      </StackPanel>
+    </Grid>
+  </Border>
+</UserControl>

--- a/AutoAuction_H2/Views/ContentPanels/AuctionOverviewView.axaml.cs
+++ b/AutoAuction_H2/Views/ContentPanels/AuctionOverviewView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AutoAuction_H2.Views.ContentPanels;
+
+public partial class AuctionOverviewView : UserControl
+{
+    public AuctionOverviewView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/AutoAuction_H2/Views/ContentPanels/LoginView.axaml
+++ b/AutoAuction_H2/Views/ContentPanels/LoginView.axaml
@@ -3,67 +3,51 @@
              xmlns:vm="clr-namespace:AutoAuction_H2.ViewModels"
              xmlns:local="clr-namespace:AutoAuction_H2.Views.ContentPanels"
              x:Class="AutoAuction_H2.Views.ContentPanels.LoginView"
-			 xmlns:views="clr-namespace:AutoAuction_H2.Views"
+             xmlns:views="clr-namespace:AutoAuction_H2.Views"
              x:DataType="vm:LoginViewModel"
              Width="800" Height="450" Background="Transparent">
 
+    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ShowGridLines="False">
+        <Image Source="avares://AutoAuction_H2/Assets/BackgroundImage.png"
+               Stretch="UniformToFill"
+               Opacity="0.7"
+               IsHitTestVisible="False"
+               Grid.RowSpan="2"
+               Grid.ColumnSpan="2"
+               Width="900"/>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="100"/>
+        </Grid.ColumnDefinitions>
+        <views:WindowButtonPanelView Grid.Row="0" Grid.Column="1" Margin="0,15,0,0"/>
 
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="10" Grid.ColumnSpan="2" Grid.RowSpan="2">
+            <Label Content="Brugernavn" FontSize="16"/>
+            <TextBox Text="{Binding Username}" Width="200" FontSize="16" Watermark="Indtast brugernavn"/>
 
-	<Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ShowGridLines="False">
+            <!-- Password (ikke skjult) -->
+            <TextBox Text="{Binding Password}" PasswordChar="•" Width="200" FontSize="16" Watermark="Indtast password"/>
+            <TextBox Text="{Binding ConfirmPassword}" PasswordChar="•" Width="200" FontSize="16" Watermark="Gentag password" IsVisible="{Binding IsCreatingUser}"/>
 
-		<Image Source="avares://AutoAuction_H2/Assets/BackgroundImage.png"
-			   Stretch="UniformToFill"
-			   Opacity="0.7"
-			   IsHitTestVisible="False"
-			   Grid.RowSpan="2"
-			   Grid.ColumnSpan="2"
-			   Width="900"
-			   />
-		<Grid.RowDefinitions>
-			<RowDefinition Height="40"/>
-			<RowDefinition Height="*"/>
-		</Grid.RowDefinitions>
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="*"/>
-			<ColumnDefinition Width="100"/>
-		</Grid.ColumnDefinitions>
-		<views:WindowButtonPanelView Grid.Row="0" Grid.Column="1" Margin="0,15,0,0"/>
+            <!-- Conditional CPR / CVR -->
+            <StackPanel IsVisible="{Binding IsCreatingUser}">
+                <TextBox Text="{Binding CprNumber}" Width="200" FontSize="16" Watermark="Indtast CPR-nummer" IsVisible="{Binding IsPrivatUser}"/>
+                <TextBox Text="{Binding CvrNumber}" Width="200" FontSize="16" Watermark="Indtast CVR-nummer" IsVisible="{Binding IsPrivatUser, Converter={StaticResource InverseBooleanConverter}}"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="20">
+                    <RadioButton Content="Privat" IsChecked="{Binding IsPrivatUser}"/>
+                    <RadioButton Content="Virksomhed" IsChecked="{Binding !IsPrivatUser }" />
+                </StackPanel>
+            </StackPanel>
 
-		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="10" Grid.ColumnSpan="2" Grid.RowSpan="2">
-
-			<Label Content="Brugernavn" FontSize="16"/>
-			<TextBox Text="{Binding Username}" Width="200" FontSize="16" Watermark="Indtast brugernavn"/>
-
-			<!-- Password -->
-			<TextBox Text="{Binding Password}" Width="200" FontSize="16" Watermark="Indtast password"/>
-			<TextBox Text="{Binding ConfirmPassword}" Width="200" FontSize="16" Watermark="Gentag password" IsVisible="{Binding IsCreatingUser}"/>
-
-			<!-- Conditional CPR / CVR -->
-			
-
-			<!-- Confirm password & role selection only shown when creating a new user -->
-			<StackPanel IsVisible="{Binding IsCreatingUser}">
-				<TextBox Text="{Binding CprNumber}" Width="200" FontSize="16" Watermark="Indtast CPR-nummer"
-					 IsVisible="{Binding IsPrivatUser}"/>
-				<TextBox Text="{Binding CvrNumber}" Width="200" FontSize="16" Watermark="Indtast CVR-nummer"
-						 IsVisible="{Binding IsPrivatUser, Converter={StaticResource InverseBooleanConverter}}"/>
-				<StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="20">
-					<RadioButton Content="Privat" IsChecked="{Binding IsPrivatUser}"/>
-					<RadioButton Content="Virksomhed" IsChecked="{Binding !IsPrivatUser }" />
-				</StackPanel>
-			</StackPanel>
-
-			<!-- Buttons -->
-			<Button Content="Login" Command="{Binding LoginCommand}" Width="200" Height="30"
-					IsVisible="{Binding IsCreatingUser, Converter={StaticResource InverseBooleanConverter}}"/>
-			<Button Content="Opret bruger" Command="{Binding ShowCreateUserCommand}" Width="200" Height="30"
-					IsVisible="{Binding IsCreatingUser, Converter={StaticResource InverseBooleanConverter}}"/>
-			<Button Content="Bekræft oprettelse" Command="{Binding CreateUserCommand}" Width="200" Height="30"
-					IsVisible="{Binding IsCreatingUser}"/>
-			<Button Content="Annuller oprettelse" Command="{Binding CancelCreateUserCommand}" Width="200" Height="30"
-					IsVisible="{Binding IsCreatingUser}"/>
-
-		</StackPanel>
-
-	</Grid>
+            <!-- Buttons -->
+            <Button Content="Login" Command="{Binding LoginCommand}" Width="200" Height="30" IsVisible="{Binding IsCreatingUser, Converter={StaticResource InverseBooleanConverter}}"/>
+            <Button Content="Opret bruger" Command="{Binding ShowCreateUserCommand}" Width="200" Height="30" IsVisible="{Binding IsCreatingUser, Converter={StaticResource InverseBooleanConverter}}"/>
+            <Button Content="Bekræft oprettelse" Command="{Binding CreateUserCommand}" Width="200" Height="30" IsVisible="{Binding IsCreatingUser}"/>
+            <Button Content="Annuller oprettelse" Command="{Binding CancelCreateUserCommand}" Width="200" Height="30" IsVisible="{Binding IsCreatingUser}"/>
+        </StackPanel>
+    </Grid>
 </UserControl>

--- a/AutoAuction_H2/Views/UIElements/ContentPanelView.axaml
+++ b/AutoAuction_H2/Views/UIElements/ContentPanelView.axaml
@@ -1,13 +1,15 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:panels="clr-namespace:AutoAuction_H2.Views.ContentPanels"
+             xmlns:vm="clr-namespace:AutoAuction_H2.ViewModels"
              x:Class="AutoAuction_H2.Views.ContentPanelView"
+             x:DataType="vm:MainViewModel"
              Background="Transparent"
              Width="600"
              Height="380">
 
 	<Border Background="Transparent" CornerRadius="10,0,0,0" BorderThickness="2,2,0,0" BorderBrush="Snow">
-		<ContentControl x:Name="RootContent">
+		<ContentControl x:Name="RootContent" Content="{Binding CurrentContent}">
 			<!--<panels:LoginView />-->
 		</ContentControl>
 	</Border>

--- a/AutoAuction_H2/Views/UIElements/LeftPanelView.axaml
+++ b/AutoAuction_H2/Views/UIElements/LeftPanelView.axaml
@@ -1,25 +1,35 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:ui="clr-namespace:AutoAuction_H2.Views.UIElements"
+             xmlns:vm="clr-namespace:AutoAuction_H2.ViewModels"
              x:Class="AutoAuction_H2.Views.LeftPanelView"
+             x:DataType="vm:MainViewModel"
 			 Width="200"
 			 Height="370">
 
 	<Border Background="Transparent" CornerRadius="10">
-		<StackPanel>
-			<!-- Menu Item 1 -->
-			<Border Background="Gray" CornerRadius="0" BorderBrush="Green" BorderThickness="0,0,0,2">
-				<TextBlock Text="Menu Item 1" Margin="5"/>
-			</Border>
-
-			<!-- Menu Item 2 -->
-			<Border Background="Gray" CornerRadius="0" BorderBrush="Green" BorderThickness="0,0,0,2">
-				<TextBlock Text="Menu Item 2" Margin="5"/>
-			</Border>
-
-			<!-- Menu Item 3 -->
-			<Border Background="Gray" CornerRadius="0" BorderBrush="Green" BorderThickness="0,0,0,2">
-				<TextBlock Text="Menu Item 3" Margin="5"/>
-			</Border>
-		</StackPanel>
+		<Grid RowDefinitions="290,*" ShowGridLines="True">
+			<StackPanel Grid.Row="0">
+				<!-- Menu Item 1 -->
+				<Border Background="Transparent" CornerRadius="0">
+					<Button Content="Hjem" Margin="5"/>
+				</Border>
+				<!-- Menu Item 2 -->
+				<Border Background="Transparent" CornerRadius="0">
+					<Button Content="Akuktionsliste" Margin="5" Command="{Binding ShowAuctionOverviewCommand}"/>
+				</Border>
+				<!-- Menu Item 3 -->
+				<!--<Border Background="Transparent" CornerRadius="0">
+					<Button Content="Opret Auktion" Margin="5"/>
+				</Border>-->
+				<Border Background="Transparent" CornerRadius="0">
+					<Button Content="Sæt til salg" Margin="5"/>
+				</Border>
+				<Border Background="Transparent" CornerRadius="0">
+					<Button Content="Auktionsoversigt" Margin="5"/>
+				</Border>
+			</StackPanel>
+			<ui:UserProfileCard Grid.Row="1"/>
+		</Grid>
 	</Border>
 </UserControl>

--- a/AutoAuction_H2/Views/UIElements/UserProfileCard.axaml
+++ b/AutoAuction_H2/Views/UIElements/UserProfileCard.axaml
@@ -1,0 +1,26 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="90"
+             x:Class="AutoAuction_H2.Views.UIElements.UserProfileCard">
+	
+    <Border CornerRadius="12" Padding="24">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Spacing="12">
+            <StackPanel>
+                <TextBlock x:Name="UsernameText" FontWeight="Bold" FontSize="15"/>
+                <TextBlock x:Name="BalanceText"  Foreground="#9c9c9c" FontSize="15"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="6" Margin="24,0,0,0">
+                <!-- Gear button -->
+                <Button Click="OpenProfile_Click" Width="28" Height="30" ToolTip.Tip="Profil" Background="Transparent" BorderBrush="Transparent">
+                    <Path Fill="WhiteSmoke" Stretch="Uniform" Width="20" Height="20" Data="M12 8a4 4 0 100 8 4 4 0 000-8zm8.94 4a7.96 7.96 0 00-.26-2l2.12-1.65a1 1 0 00.24-1.31l-2-3.46a1 1 0 00-1.2-.45l-2.49 1a8.06 8.06 0 00-1.73-1l-.38-2.65A1 1 0 0013.92 0h-3.84a1 1 0 00-1 .83L8.7 3.48a8.06 8.06 0 00-1.73 1l-2.49-1a1 1 0 00-1.2.45l-2 3.46a1 1 0 00.24 1.31L3.64 10a7.96 7.96 0 000 4L1.52 15.65a1 1 0 00-.24 1.31l2 3.46a1 1 0 001.2.45l2.49-1a8.06 8.06 0 001.73 1l.38 2.65a1 1 0 001 .83h3.84a1 1 0 001-.83l.38-2.65a8.06 8.06 0 001.73-1l2.49 1a1 1 0 001.2-.45l2-3.46a1 1 0 00-.24-1.31L20.68 14a7.96 7.96 0 00.26-2z" />
+                </Button>
+                <!-- Logout button -->
+                <Button Click="Logout_Click" Width="28" Height="30" ToolTip.Tip="Log ud" Background="Transparent" BorderBrush="Transparent">
+                    <Path Fill="WhiteSmoke" Stretch="Uniform" Width="20" Height="20" Data="M3,3 L3,21 L13,21 L13,17 L11,17 L11,19 L5,19 L5,5 L11,5 L11,7 L13,7 L13,3 Z M17,12 L13,8 L13,11 L7,11 L7,13 L13,13 L13,16 Z"/>
+                </Button>
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/AutoAuction_H2/Views/UIElements/UserProfileCard.axaml.cs
+++ b/AutoAuction_H2/Views/UIElements/UserProfileCard.axaml.cs
@@ -1,0 +1,56 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using AutoAuction_H2.Views.ContentPanels;
+using AutoAuction_H2.ViewModels;
+using AutoAuction_H2.Views.Windows;
+
+namespace AutoAuction_H2.Views.UIElements;
+
+public partial class UserProfileCard : UserControl
+{
+    private TextBlock? _usernameTextBlock;
+    private TextBlock? _balanceTextBlock;
+
+    public UserProfileCard()
+    {
+        InitializeComponent();
+        this.AttachedToVisualTree += OnAttachedToVisualTree;
+    }
+
+    private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _usernameTextBlock = this.FindControl<TextBlock>("UsernameText");
+        if (_usernameTextBlock != null)
+            _usernameTextBlock.Text = LoginViewModel.CurrentUsername ?? "Brugernavn";
+
+        _balanceTextBlock = this.FindControl<TextBlock>("BalanceText");
+        if (_balanceTextBlock != null)
+            _balanceTextBlock.Text = $"Saldo: {LoginViewModel.CurrentBalance:N0} kr";
+    }
+
+    private void Logout_Click(object? sender, RoutedEventArgs e)
+    {
+        if (VisualRoot is Window window && window is MainWindow mainWindow)
+        {
+            var loginVm = new LoginViewModel();
+            loginVm.LoggedIn += mainWindow.ShowMainView;
+            var loginView = new LoginView { DataContext = loginVm };
+            mainWindow.MainContent.Content = loginView;
+        }
+    }
+
+    private async void OpenProfile_Click(object? sender, RoutedEventArgs e)
+    {
+        var win = new UserProfileWindow();
+        if (VisualRoot is Window owner)
+        {
+            await win.ShowDialog(owner);
+        }
+        else
+        {
+            win.Show();
+        }
+    }
+}

--- a/AutoAuction_H2/Views/Windows/ChangePasswordWindow.axaml
+++ b/AutoAuction_H2/Views/Windows/ChangePasswordWindow.axaml
@@ -1,0 +1,40 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="AutoAuction_H2.Views.Windows.ChangePasswordWindow"
+        Width="440" Height="340"
+        Title="Skift adgangskode"
+        SystemDecorations="None"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="NoChrome"
+        ExtendClientAreaTitleBarHeightHint="-1"
+        TransparencyLevelHint="AcrylicBlur,Transparent,Blur"
+        Background="Transparent"
+        CanResize="False">
+	
+  <Border Padding="24" CornerRadius="12" Background="{StaticResource PanelBackgroundBrush}">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="16">
+		
+      <TextBlock Text="Skift adgangskode" FontSize="22" FontWeight="Bold"/>
+
+      <Border Grid.Row="1" CornerRadius="8" Background="{StaticResource CardBackgroundBrush}" Padding="12">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*" RowSpacing="10" ColumnSpacing="12">
+          <TextBlock Text="Nuværende:" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
+          <TextBox Grid.Row="0" Grid.Column="1" PasswordChar="•" Text="{Binding CurrentPassword}"/>
+
+          <TextBlock Text="Ny adgangskode:" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
+          <TextBox Grid.Row="1" Grid.Column="1" PasswordChar="•" Text="{Binding NewPassword}"/>
+
+          <TextBlock Text="Bekræft ny:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
+          <TextBox Grid.Row="2" Grid.Column="1" PasswordChar="•" Text="{Binding ConfirmPassword}"/>
+
+          <TextBlock Grid.Row="3" Grid.ColumnSpan="2" Foreground="Tomato" TextWrapping="Wrap" Text="{Binding ErrorMessage}"/>
+        </Grid>
+      </Border>
+
+      <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+        <Button Content="Annuller" Width="100" Click="Cancel_Click"/>
+        <Button Content="Gem" Width="100" Command="{Binding SaveCommand}"/>
+      </StackPanel>
+    </Grid>
+  </Border>
+</Window>

--- a/AutoAuction_H2/Views/Windows/ChangePasswordWindow.axaml.cs
+++ b/AutoAuction_H2/Views/Windows/ChangePasswordWindow.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using AutoAuction_H2.ViewModels;
+
+namespace AutoAuction_H2.Views.Windows;
+
+public partial class ChangePasswordWindow : Window
+{
+    public ChangePasswordWindow()
+    {
+        InitializeComponent();
+        DataContext = new ChangePasswordViewModel();
+    }
+
+    private void Cancel_Click(object? sender, RoutedEventArgs e) => Close();
+}

--- a/AutoAuction_H2/Views/Windows/CreateAuctionWindow.axaml
+++ b/AutoAuction_H2/Views/Windows/CreateAuctionWindow.axaml
@@ -1,0 +1,30 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:AutoAuction_H2.Views.Auction.Controls"
+        x:Class="AutoAuction_H2.Views.Windows.CreateAuctionWindow"
+        Width="900" Height="580"
+        Title="Sæt til salg"
+        SystemDecorations="None"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="NoChrome"
+        ExtendClientAreaTitleBarHeightHint="-1"
+        TransparencyLevelHint="AcrylicBlur,Transparent,Blur"
+        Background="Transparent"
+        CanResize="False">
+  <Border Padding="24" CornerRadius="12" Background="{StaticResource PanelBackgroundBrush}">
+    <Grid RowDefinitions="Auto,*,Auto" RowSpacing="20">
+      <TextBlock Text="Sæt til salg" FontSize="22" FontWeight="Bold"/>
+
+      <Grid Grid.Row="1" ColumnDefinitions="*,*" ColumnSpacing="20">
+        <controls:CreateAuctionBasicInfoCard/>
+        <controls:CreateAuctionVehicleDetailsCard Grid.Column="1"/>
+      </Grid>
+
+      <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="12">
+        <TextBlock Foreground="Tomato" Text="{Binding ErrorMessage}" VerticalAlignment="Center"/>
+        <Button Content="Annuller" Width="120" Click="Cancel_Click"/>
+        <Button Content="Opret auktion" Width="160" Classes="accent" Command="{Binding CreateCommand}"/>
+      </StackPanel>
+    </Grid>
+  </Border>
+</Window>

--- a/AutoAuction_H2/Views/Windows/CreateAuctionWindow.axaml.cs
+++ b/AutoAuction_H2/Views/Windows/CreateAuctionWindow.axaml.cs
@@ -1,0 +1,31 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using AutoAuction_H2.ViewModels;
+
+namespace AutoAuction_H2.Views.Windows;
+
+public partial class CreateAuctionWindow : Window
+{
+    public CreateAuctionWindow()
+    {
+        InitializeComponent();
+        var vm = new CreateAuctionViewModel();
+        vm.AuctionCreated += OnAuctionCreated;
+        DataContext = vm;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private async void OnAuctionCreated(object? sender, System.EventArgs e)
+    {
+        var toast = new ToastWindow();
+        await toast.ShowAsync("Auktion oprettet", this);
+        Close();
+    }
+
+    private void Cancel_Click(object? sender, RoutedEventArgs e) => Close();
+}

--- a/AutoAuction_H2/Views/Windows/ToastWindow.axaml
+++ b/AutoAuction_H2/Views/Windows/ToastWindow.axaml
@@ -1,0 +1,16 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="AutoAuction_H2.Views.Windows.ToastWindow"
+        Width="260" Height="80"
+        SystemDecorations="None"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="NoChrome"
+        ExtendClientAreaTitleBarHeightHint="-1"
+        TransparencyLevelHint="AcrylicBlur,Transparent,Blur"
+        Background="Transparent"
+        CanResize="False"
+        Topmost="True">
+  <Border Padding="12" CornerRadius="10" Background="{StaticResource CardBackgroundBrush}">
+    <TextBlock x:Name="MessageText" Text="" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+  </Border>
+</Window>

--- a/AutoAuction_H2/Views/Windows/ToastWindow.axaml.cs
+++ b/AutoAuction_H2/Views/Windows/ToastWindow.axaml.cs
@@ -1,0 +1,34 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using System.Threading.Tasks;
+
+namespace AutoAuction_H2.Views.Windows;
+
+public partial class ToastWindow : Window
+{
+    public ToastWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public async Task ShowAsync(string message, Window? owner = null, int milliseconds = 2000)
+    {
+        if (this.FindControl<TextBlock>("MessageText") is { } tb)
+            tb.Text = message;
+
+        if (owner != null)
+        {
+            Position = new PixelPoint(owner.Position.X + 20, owner.Position.Y + 20);
+        }
+
+        Show();
+        await Task.Delay(milliseconds);
+        Close();
+    }
+}

--- a/AutoAuction_H2/Views/Windows/UserProfileWindow.axaml
+++ b/AutoAuction_H2/Views/Windows/UserProfileWindow.axaml
@@ -1,0 +1,64 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:AutoAuction_H2.ViewModels"
+        x:Class="AutoAuction_H2.Views.Windows.UserProfileWindow"
+        Width="560" Height="400"
+        SystemDecorations="None"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="NoChrome"
+        ExtendClientAreaTitleBarHeightHint="-1"
+        Title="Din profil"
+        CanResize="False"
+        TransparencyLevelHint="AcrylicBlur,Transparent,Blur"
+        Background="Transparent">
+  <Border Padding="24" CornerRadius="12" Background="{StaticResource PanelBackgroundBrush}">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*" >
+      <!-- Background image -->
+      <Image Source="avares://AutoAuction_H2/Assets/BackgroundImage.png"
+             Stretch="UniformToFill"
+             Opacity="0.25"
+             IsHitTestVisible="False"
+             Grid.RowSpan="4"
+             />
+
+      <!-- Header -->
+      <TextBlock Grid.Row="0" Text="Din profil" FontSize="26" FontWeight="Bold"/>
+
+      <!-- Profile details -->
+      <Border Grid.Row="1" CornerRadius="8" Background="{StaticResource CardBackgroundBrush}" Padding="12" Margin="0,18,0,12">
+        <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Text="Brugernavn:" Grid.Row="0" Grid.Column="0" Margin="0,0,12,8"/>
+          <TextBlock Text="{Binding Username}" Grid.Row="0" Grid.Column="1" Margin="0,0,12,8"/>
+
+          <TextBlock Text="Adgangskode:" Grid.Row="1" Grid.Column="0" Margin="0,0,12,8"/>
+          <TextBlock Text="••••••••" Grid.Row="1" Grid.Column="1" Margin="0,0,12,8"/>
+          <Button Content="Skift adgangskode" Grid.Row="1" Grid.Column="2" MinWidth="150" Click="ChangePassword_Click"/>
+
+          <TextBlock Text="Saldo:" Grid.Row="2" Grid.Column="0" Margin="0,0,12,0"/>
+          <TextBlock Text="{Binding Balance, StringFormat='{}{0:N0} kr'}" Grid.Row="2" Grid.Column="1"/>
+        </Grid>
+      </Border>
+
+      <!-- Stats cards -->
+      <Grid Grid.Row="2" ColumnDefinitions="*,*" ColumnSpacing="12" Margin="0,8,0,16">
+        <Border CornerRadius="8" Padding="12" Background="{StaticResource CardBackgroundBrush}">
+          <StackPanel>
+            <TextBlock Text="Dine auktioner" FontWeight="SemiBold"/>
+            <TextBlock Text="{Binding YourAuctionsCount}" FontSize="20"/>
+          </StackPanel>
+        </Border>
+        <Border CornerRadius="8" Padding="12" Grid.Column="1" Background="{StaticResource CardBackgroundBrush}">
+          <StackPanel>
+            <TextBlock Text="Vundne auktioner" FontWeight="SemiBold"/>
+            <TextBlock Text="{Binding AuctionsWonCount}" FontSize="20"/>
+          </StackPanel>
+        </Border>
+      </Grid>
+
+      <!-- Footer -->
+      <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Left">
+        <Button Width="120" Content="Luk" Click="Close_Click"/>
+      </StackPanel>
+    </Grid>
+  </Border>
+</Window>

--- a/AutoAuction_H2/Views/Windows/UserProfileWindow.axaml.cs
+++ b/AutoAuction_H2/Views/Windows/UserProfileWindow.axaml.cs
@@ -1,0 +1,41 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using AutoAuction_H2.ViewModels;
+
+namespace AutoAuction_H2.Views.Windows;
+
+public partial class UserProfileWindow : Window
+{
+    public UserProfileWindow()
+    {
+        InitializeComponent();
+
+        // Simple view model with current session data
+        DataContext = new UserProfileViewModel
+        {
+            Username = LoginViewModel.CurrentUsername ?? "Unknown",
+            Balance = LoginViewModel.CurrentBalance,
+            YourAuctionsCount = 2,
+            AuctionsWonCount = 1
+        };
+    }
+
+    private void Close_Click(object? sender, RoutedEventArgs e) => Close();
+
+    private async void ChangePassword_Click(object? sender, RoutedEventArgs e)
+    {
+        var dlg = new ChangePasswordWindow();
+
+        if (dlg.DataContext is ChangePasswordViewModel vm)
+        {
+            void Handler(object? s, System.EventArgs e)
+            {
+                vm.PasswordChanged -= Handler;
+                dlg.Close();
+            }
+            vm.PasswordChanged += Handler;
+        }
+
+        await dlg.ShowDialog(this);
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Avalonia.iOS" Version="11.3.5" />
     <PackageVersion Include="Avalonia.Browser" Version="11.3.5" />
     <PackageVersion Include="Avalonia.Android" Version="11.3.5" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.5" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.15" />
   </ItemGroup>


### PR DESCRIPTION
• Add CreateAuctionWindow with two reusable cards: • CreateAuctionBasicInfoCard (Navn, Startbud, Slutdato) • CreateAuctionVehicleDetailsCard (Kilometer, Reg.nr., Årgang, køretøjsfelter, Træk) • Add CreateAuctionViewModel with validation and DateTimeOffset? CloseDate (fixes DatePicker binding) • Wire “+ Sæt til salg” in AuctionSidebar to open CreateAuctionWindow • Add ToastWindow and show confirmation on successful creation • Introduce PanelShell (shared panel + background image) and use it in: • CreateAuctionWindow
• UserProfileWindow
• AuctionOverviewView
• Build AuctionOverview from components:
• AuctionSidebar (narrowed; search watermark fixed for ø) • AuctionTable (DataGrid-based), add Models/AuctionItem • Move AuctionOverviewView to Views/ContentPanels and enhance with layout • Unify app styling:
• App.axaml: PanelBackgroundBrush, CardBackgroundBrush, AccentBrush • Global styles for Button.accent/.secondary, TextBox.search, TextBlock.bid, DataGrid • Apply styles across windows and controls
• User windows:
• UserProfileWindow + ChangePasswordWindow: same chrome as MainWindow, Danish labels • ChangePassword flow (ChangePasswordWindow + ViewModel) • Fixes/infra:
• Add Avalonia.Controls.DataGrid via central package (Directory.Packages.props) • Resolve encoding issues for ø (numeric entity in watermark) • Remove unsupported DatePicker DisplayDateFormat
• InitializeComponent implementations for new views/controls • Layout polish:
• Increase spacing/padding, align labels/inputs, consistent headers and separators • Sidebar width reduced to give more space to data

UserProfile & Login

UserProfileCard så vi får et brugernavn samt vi kan se vores saldo, og kan logge ud med en knap der er lavet.

Login
- Password har fået PasswordChar så man ikke kan se password når man logger ind og skriver det i textboksen.